### PR TITLE
Pass signals to the launcher command from the wrapper script

### DIFF
--- a/src/main/resources/launcher
+++ b/src/main/resources/launcher
@@ -40,4 +40,4 @@ if [ ! -f "${LAUNCHER_BIN}" ]; then
   exit 1
 fi
 
-"${LAUNCHER_BIN}" "$@"
+exec "${LAUNCHER_BIN}" "$@"


### PR DESCRIPTION
Without this, if the launcher is used in a Docker container, the container will never terminate gracefully.

I tested this manually in Trino 466, which is affected by this behavior.