### PR TITLE
Fix passing multiple jvm options through launcher

### DIFF
--- a/src/main/go/args/java_execution.go
+++ b/src/main/go/args/java_execution.go
@@ -110,7 +110,7 @@ func (options *Options) JavaExecution(daemonize bool) ([]string, []string, error
 	}
 
 	if len(options.JvmOptions) != 0 {
-		command = append(command, strings.Join(options.JvmOptions, " "))
+		command = append(command, options.JvmOptions...)
 	}
 	system := getArchSpecificDirectory()
 	agentName := options.LauncherConfig["agent-name"]

--- a/src/main/go/args/java_execution.go
+++ b/src/main/go/args/java_execution.go
@@ -96,7 +96,7 @@ func (options *Options) JavaExecution(daemonize bool) ([]string, []string, error
 	command := []string{javaBin, "-cp", classpath}
 	command = append(command, options.JvmConfig...)
 
-    majorJavaVersion := GetMajorJavaVersion(jdkVersion);
+	majorJavaVersion := GetMajorJavaVersion(jdkVersion)
 	if perJdkConfigs, exists := jvmSpecificConfig[majorJavaVersion]; exists {
 		for _, perJdkConfig := range perJdkConfigs {
 			if perJdkConfig != "" {
@@ -104,11 +104,10 @@ func (options *Options) JavaExecution(daemonize bool) ([]string, []string, error
 			}
 		}
 
-        if options.Verbose {
-            fmt.Printf("Implicit JVM %s config: %v\n", majorJavaVersion, perJdkConfigs)
-        }
+		if options.Verbose {
+			fmt.Printf("Implicit JVM %s config: %v\n", majorJavaVersion, perJdkConfigs)
+		}
 	}
-
 
 	if len(options.JvmOptions) != 0 {
 		command = append(command, strings.Join(options.JvmOptions, " "))

--- a/src/main/go/args/java_execution_test.go
+++ b/src/main/go/args/java_execution_test.go
@@ -1,6 +1,9 @@
 package args
 
-import "testing"
+import (
+	"os/exec"
+	"testing"
+)
 
 func TestParsingJvmVersion(t *testing.T) {
 	testCases := []struct {
@@ -25,5 +28,35 @@ func TestParsingJvmVersion(t *testing.T) {
 		if actualVersion != testCase.expectedVersion {
 			t.Fatalf("Expected Java version %s for output %s", testCase.expectedVersion, testCase.output)
 		}
+	}
+}
+
+func TestJavaExecutionMultipleJvmOptions(t *testing.T) {
+	if _, err := exec.LookPath("java"); err != nil {
+		t.Skip("java not on PATH")
+	}
+
+	options := &Options{
+		JvmConfig:        []string{},
+		JvmOptions:       []string{"-Xmx4g", "-Xms2g"},
+		LauncherConfig:   map[string]string{"main-class": "com.example.Main"},
+		SystemProperties: map[string]string{},
+		ConfigPath:       "/etc/config.properties",
+	}
+
+	command, _, err := options.JavaExecution(false)
+	if err != nil {
+		t.Fatalf("JavaExecution failed: %v", err)
+	}
+
+	found := false
+	for i := 0; i < len(command)-1; i++ {
+		if command[i] == "-Xmx4g" && command[i+1] == "-Xms2g" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected -Xmx4g and -Xms2g as consecutive separate arguments, got: %v", command)
 	}
 }

--- a/src/main/go/properties/properties_test.go
+++ b/src/main/go/properties/properties_test.go
@@ -126,7 +126,7 @@ func TestLoad(t *testing.T) {
 					different = append(different, fmt.Sprintf("Expected value for key %s to be `%s` but got `%s`", key, expectedValue, actualValue))
 				}
 			}
-			for key, _ := range actual {
+			for key := range actual {
 				_, ok := tc.expected[key]
 				if !ok {
 					additional = append(additional, key)


### PR DESCRIPTION
    Fix passing multiple jvm options through launcher
    
    Pass each jvm option as separate argument to exec.
    Previously used whitespace delimiter per argument,
    this is not correct when fed directly to exec.

When running this command:
```
Command:
/opt/app/bin/launcher
run
--config=/opt/app/config/config.properties
--log-levels-file=/opt/app/config/log.properties
-J-XX:InitialRAMPercentage=80
-J-XX:MaxRAMPercentage=80
```

the resulting error:
```
Improperly specified VM option 'InitialRAMPercentage=80 -XX:MaxRAMPercentage=80'
Error: Could not create the Java Virtual Machine.
Error: A fatal exception has occurred. Program will exit.
```